### PR TITLE
feat: Move configuration of SAML SSO - Meeds-io/MIPs#42 - EXO-62860

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,16 +84,6 @@
         <type>zip</type>
       </dependency>
       <dependency>
-        <groupId>org.exoplatform.gatein.portal</groupId>
-        <artifactId>exo.portal.component.web.sso.integration-configs</artifactId>
-        <version>${org.exoplatform.gatein.portal.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.gatein.portal</groupId>
-        <artifactId>exo.portal.component.web.sso.agents-configs</artifactId>
-        <version>${org.exoplatform.gatein.portal.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.picketlink</groupId>
         <artifactId>picketlink-federation</artifactId>
         <version>${version.picketlink.fed}</version>


### PR DESCRIPTION
Prior to this change, the SAML SSO configuration was defined in GateIN-Portal instead of centralizing it here. This change will import the configuration from GateIN-PORTAL to this addon for better modularity and clean separation between layers.