### PR TITLE
feat: Move configuration of SAML SSO - Meeds-io/MIPs#42 - EXO-62860

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -35,20 +35,17 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>saml2-addon-service</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.exoplatform.gatein.sso</groupId>
       <artifactId>sso-auth-callback</artifactId>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.sso</groupId>
       <artifactId>sso-saml-plugin</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.web.sso.integration-configs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.web.sso.agents-configs</artifactId>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.sso</groupId>

--- a/packaging/src/main/assemblies/exo-saml-addon.xml
+++ b/packaging/src/main/assemblies/exo-saml-addon.xml
@@ -48,8 +48,7 @@
         <include>org.picketbox:jboss-security-spi</include>
         <include>org.exoplatform.gatein.sso:sso-auth-callback</include>
         <include>org.exoplatform.gatein.sso:sso-saml-plugin</include>
-        <include>org.exoplatform.gatein.portal:exo.portal.component.web.sso.integration-configs</include>
-        <include>org.exoplatform.gatein.portal:exo.portal.component.web.sso.agents-configs</include>
+        <include>org.exoplatform.addons.sso:saml2-addon-service</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
   </scm>
 
   <modules>
+    <module>service</module>
     <module>packaging</module>
   </modules>
 
@@ -62,6 +63,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>saml2-addon-service</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.exoplatform.gatein.sso</groupId>
         <artifactId>sso-auth-callback</artifactId>
         <version>${org.exoplatform.gatein.sso.version}</version>
@@ -76,16 +82,6 @@
         <artifactId>sso-packaging</artifactId>
         <version>${org.exoplatform.gatein.sso.version}</version>
         <type>zip</type>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.gatein.portal</groupId>
-        <artifactId>exo.portal.component.web.sso.integration-configs</artifactId>
-        <version>${org.exoplatform.gatein.portal.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.gatein.portal</groupId>
-        <artifactId>exo.portal.component.web.sso.agents-configs</artifactId>
-        <version>${org.exoplatform.gatein.portal.version}</version>
       </dependency>
       <dependency>
         <groupId>org.picketlink</groupId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Copyright (C) 2003-2023 eXo Platform SAS.
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Affero General Public License
+  as published by the Free Software Foundation; either version 3
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, see<http://www.gnu.org/licenses />.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.sso</groupId>
+    <artifactId>saml2-addon-parent</artifactId>
+    <version>3.5.x-SNAPSHOT</version>
+  </parent>
+  <artifactId>saml2-addon-service</artifactId>
+  <name>eXo Add-on:: SAML2 add-on Service</name>
+  <description>The SAML2 add-on Service</description>
+  <build>
+    <finalName>${project.artifactId}</finalName>
+  </build>
+</project>

--- a/service/src/main/resources/conf/portal/configuration.xml
+++ b/service/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  Copyright (C) 2003-2023 eXo Platform SAS.
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Affero General Public License
+  as published by the Free Software Foundation; either version 3
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, see<http://www.gnu.org/licenses />.
+-->
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.gatein.sso.integration.SSOFilterIntegrator</target-component>
+    <component-plugin>
+      <name>LoginRedirectFilter</name>
+      <set-method>addPlugin</set-method>
+      <type>org.gatein.sso.integration.SSOFilterIntegratorPlugin</type>
+      <init-params>
+        <value-param>
+          <name>filterClass</name>
+          <value>org.gatein.sso.agent.filter.LoginRedirectFilter</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>${gatein.sso.filter.login.enabled:true}</value>
+        </value-param>
+        <value-param>
+          <name>filterMapping</name>
+          <value>/sso</value>
+        </value-param>
+        <value-param>
+          <name>LOGIN_URL</name>
+          <value>${gatein.sso.filter.login.sso.url}</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.gatein.sso.integration.SSOFilterIntegrator</target-component>
+    <component-plugin>
+      <name>LogoutFilter</name>
+      <set-method>addPlugin</set-method>
+      <type>org.gatein.sso.integration.SSOFilterIntegratorPlugin</type>
+      <init-params>
+        <value-param>
+          <name>filterClass</name>
+          <value>${gatein.sso.filter.logout.class}</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>${gatein.sso.filter.logout.enabled:true}</value>
+        </value-param>
+        <value-param>
+          <name>filterMapping</name>
+          <value>/*</value>
+        </value-param>
+        <value-param>
+          <name>CONFIG_FILE</name>
+          <value>${exo.conf.dir}/saml2/picketlink-sp.xml</value>
+        </value-param>
+        <value-param>
+          <name>IGNORE_SIGNATURES</name>
+          <value>${gatein.sso.saml.signature.ignore:true}</value>
+        </value-param>
+        <value-param>
+          <name>ROLES</name>
+          <value>users</value>
+        </value-param>
+        <value-param>
+          <name>LOGOUT_URL</name>
+          <value>${gatein.sso.filter.logout.url}</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+</configuration>


### PR DESCRIPTION
Prior to this change, the SAML SSO configuration was defined in GateIN-Portal instead of centralizing it here. This change will import the configuration from GateIN-PORTAL to this addon for better modularity and clean separation between layers.