### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -48,11 +48,6 @@
       <artifactId>sso-saml-plugin</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.gatein.sso</groupId>
-      <artifactId>sso-packaging</artifactId>
-      <type>zip</type>
-    </dependency>
-    <dependency>
       <groupId>org.picketlink</groupId>
       <artifactId>picketlink-common</artifactId>
     </dependency>
@@ -73,30 +68,6 @@
   <build>
     <finalName>${project.artifactId}-${project.version}</finalName>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>unpack</id>
-            <phase>package</phase>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.exoplatform.gatein.sso</groupId>
-                  <artifactId>sso-packaging</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${project.build.directory}/sso-packaging.zip</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-              <!-- other configurations here -->
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.exoplatform.addons</groupId>
-    <artifactId>addons-parent-exo-pom</artifactId>
+    <artifactId>addons-exo-parent-pom</artifactId>
     <version>17-security-fix-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.addons.sso</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>addons-exo-parent-pom</artifactId>
-    <version>17-security-fix-SNAPSHOT</version>
+    <version>17-M01</version>
   </parent>
   <groupId>org.exoplatform.addons.sso</groupId>
   <artifactId>saml2-addon-parent</artifactId>
@@ -51,7 +51,7 @@
     <!-- **************************************** -->
     <!-- Dependencies versions -->
     <!-- **************************************** -->
-    <org.exoplatform.commons-exo.version>6.5.x-security-fix-SNAPSHOT</org.exoplatform.commons-exo.version>
+    <org.exoplatform.commons-exo.version>6.5.x-SNAPSHOT</org.exoplatform.commons-exo.version>
     <org.picketbox.jboss-security-spi.version>3.0.0.Final</org.picketbox.jboss-security-spi.version>
     <version.picketlink.fed>2.5.5.Final</version.picketlink.fed>
   

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.exoplatform.addons</groupId>
-    <artifactId>addons-parent-pom</artifactId>
-    <version>17-exo-M01</version>
+    <artifactId>addons-parent-exo-pom</artifactId>
+    <version>17-security-fix-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.addons.sso</groupId>
   <artifactId>saml2-addon-parent</artifactId>
@@ -51,8 +51,7 @@
     <!-- **************************************** -->
     <!-- Dependencies versions -->
     <!-- **************************************** -->
-    <org.exoplatform.gatein.portal.version>6.5.x-exo-SNAPSHOT</org.exoplatform.gatein.portal.version>
-    <org.exoplatform.gatein.sso.version>6.5.x-exo-SNAPSHOT</org.exoplatform.gatein.sso.version>
+    <org.exoplatform.commons-exo.version>6.5.x-security-fix-SNAPSHOT</org.exoplatform.commons-exo.version>
     <org.picketbox.jboss-security-spi.version>3.0.0.Final</org.picketbox.jboss-security-spi.version>
     <version.picketlink.fed>2.5.5.Final</version.picketlink.fed>
   
@@ -63,26 +62,18 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.exoplatform.commons-exo</groupId>
+        <artifactId>commons-exo</artifactId>
+        <version>${org.exoplatform.commons-exo.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>saml2-addon-service</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.exoplatform.gatein.sso</groupId>
-        <artifactId>sso-auth-callback</artifactId>
-        <version>${org.exoplatform.gatein.sso.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.gatein.sso</groupId>
-        <artifactId>sso-saml-plugin</artifactId>
-        <version>${org.exoplatform.gatein.sso.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.gatein.sso</groupId>
-        <artifactId>sso-packaging</artifactId>
-        <version>${org.exoplatform.gatein.sso.version}</version>
-        <type>zip</type>
-      </dependency>
+
       <dependency>
         <groupId>org.picketlink</groupId>
         <artifactId>picketlink-federation</artifactId>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds