### PR TITLE
fix: SAML2 Logout not workibg - EXO-70293

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ gatein.sso.sp.host=SP_HOSTNAME
 gatein.sso.sp.url=${gatein.sso.sp.host}/portal/dologin
 gatein.sso.idp.host=IDP_HOSTNAME
 gatein.sso.idp.url=IDP_SAML_ENDPOINT
+gatein.sso.idp.url.logout=IDP_SAML_ENDPOINT_LOGOUT
 gatein.sso.idp.alias=IDP_SIGNING_ALIAS
 gatein.sso.idp.signingkeypass=IDP_SIGNING_KEY_PASS
 gatein.sso.idp.keystorepass=IDP_KEYSTORE_PASS
@@ -34,6 +35,7 @@ gatein.sso.picketlink.keystore=${exo.conf.dir}/saml2/jbid_test_keystore.jks
 Note: The following properties values must be configured
 ```
 IDP_SAML_ENDPOINT: Saml IDP Endpoint: Example, http://idp.com/saml
+IDP_SAML_ENDPOINT_LOGOUT: Saml IDP Logout Endpoint: Example, http://idp.com/saml/logout
 IDP_SIGNING_ALIAS: Certificate Alias in selected Keystore file, Example: idpalias
 IDP_SIGNING_KEY_PASS: Certificates Keystore Password, Example: test123
 IDP_KEYSTORE_PASS: SSL Keystore Password, Example: store123

--- a/packaging/src/main/resources/exo-saml2-config/gatein/conf/saml2/picketlink-sp.xml
+++ b/packaging/src/main/resources/exo-saml2-config/gatein/conf/saml2/picketlink-sp.xml
@@ -1,6 +1,6 @@
 <PicketLink xmlns="urn:picketlink:identity-federation:config:2.1">
   <PicketLinkSP xmlns="urn:picketlink:identity-federation:config:2.1"
-                ServerEnvironment="tomcat" BindingType="POST" SupportsSignatures="true" LogOutPage="/">
+                ServerEnvironment="tomcat" BindingType="POST" SupportsSignatures="true" LogOutPage="/" LogOutUrl="${gatein.sso.idp.url.logout::/logout}">
     <IdentityURL>${gatein.sso.idp.url}</IdentityURL>
     <ServiceURL>${gatein.sso.sp.url}</ServiceURL>
 


### PR DESCRIPTION
Before this fix, SAML2 logout not working as idp redirection on logout was done on the same url as login This commit allow to configure a logout url in picketlink-sp.xml, and redirect on it during logout process

Resolves meeds-io/meeds-1771