### PR TITLE
Fix : jar xmlsec is missing when using assertion encryption - EXO-70567

### DIFF
--- a/packaging/src/main/assemblies/exo-saml-addon.xml
+++ b/packaging/src/main/assemblies/exo-saml-addon.xml
@@ -43,6 +43,7 @@
       <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>org.exoplatform.gatein.sso:sso-saml-plugin</include>
+        <include>org.apache.santuario:xmlsec</include>
       </includes>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>


### PR DESCRIPTION
Before this fix, when IDP encrypt assertion, there is a class not found exception This is due to a missing jar xmlsec
This pr adds the missing jar in addon packaging