### PR TITLE
Fix : jar xmlsec is missing when using assertion encryption - EXO-70567

### DIFF
--- a/packaging/src/main/assemblies/exo-saml-addon.xml
+++ b/packaging/src/main/assemblies/exo-saml-addon.xml
@@ -49,6 +49,7 @@
         <include>org.exoplatform.gatein.sso:sso-auth-callback</include>
         <include>org.exoplatform.gatein.sso:sso-saml-plugin</include>
         <include>org.exoplatform.addons.sso:saml2-addon-service</include>
+        <include>org.apache.santuario:xmlsec</include>
       </includes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
Before this fix, when IDP encrypt assertion, there is a class not found exception This is due to a missing jar xmlsec
This pr adds the missing jar in addon packaging