### PR TITLE
feat: Productize the addon saml-extension - EXO-69764

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,13 @@ To configure it, there is 2 options :
   - unspecified : then you can choose a user attribute like username as name id
 - On exo side : the property `gatein.sso.saml.nameid.format` allow to configure the wanted nameid format. By dafault, value is `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`. It can be changed to `urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified` if needed
 
-gatein.sso.saml.nameid.format
+#### Set username in other field than nameid
+In some installation, IDP requires that nameid is not the username but a numeric id. In this case, you can set the username in another field by setting theses properties in exo.properties
+```
+gatein.sso.saml.use.namedid=false
+gatein.sso.saml.subject.attribute=uid
+```
+
+With this configuration, the username or email will be read in the attribute provided by the assertion.
+
+

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -38,6 +38,10 @@
       <groupId>io.meeds.gatein.sso</groupId>
       <artifactId>sso-saml-plugin</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.exoplatform.addons.sso</groupId>
+      <artifactId>saml2-addon-service</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/packaging/src/main/assemblies/exo-saml-addon.xml
+++ b/packaging/src/main/assemblies/exo-saml-addon.xml
@@ -43,6 +43,7 @@
       <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>io.meeds.gatein.sso:sso-saml-plugin</include>
+        <include>org.exoplatform.addons.sso:saml2-addon-service</include>
         <include>org.apache.santuario:xmlsec</include>
       </includes>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>

--- a/packaging/src/main/resources/exo-saml2-config/gatein/conf/saml2/picketlink-sp.xml
+++ b/packaging/src/main/resources/exo-saml2-config/gatein/conf/saml2/picketlink-sp.xml
@@ -21,17 +21,20 @@
     <Handler
         class="org.gatein.sso.agent.saml.PortalSAML2LogOutHandler"/>
     <Handler
-        class="org.picketlink.identity.federation.web.handlers.saml2.SAML2AuthenticationHandler">
-      <Option Key="NAMEID_FORMAT" Value="${gatein.sso.saml.nameid.format::urn:oasis:names:tc:SAML:2.0:nameid-format:persistent}"/>    </Handler>
+        class="org.exoplatform.addons.saml.extensions.SAML2ExtendedAuthenticationHandler">
+      <Option Key="NAMEID_FORMAT" Value="${gatein.sso.saml.nameid.format::urn:oasis:names:tc:SAML:2.0:nameid-format:persistent}"/>
+      <Option Key="USE_NAMEID" Value="${gatein.sso.saml.use.namedid::true}"/>
+      <Option Key="SUBJECT_ATTRIBUTE" Value="${gatein.sso.saml.subject.attribute::uid}"/>
+    </Handler>
     <Handler
         class="org.picketlink.identity.federation.web.handlers.saml2.RolesGenerationHandler"/>
 
-  <!-- <Handler 
-        class="org.picketlink.identity.federation.web.handlers.saml2.SAML2IssuerTrustHandler" /> -->
-  <!-- <Handler 
-        class="org.picketlink.identity.federation.web.handlers.saml2.SAML2SignatureGenerationHandler" /> -->
-  <!-- <Handler 
-        class="org.picketlink.identity.federation.web.handlers.saml2.SAML2SignatureValidationHandler"/> -->
+    <!-- <Handler
+          class="org.picketlink.identity.federation.web.handlers.saml2.SAML2IssuerTrustHandler" /> -->
+    <!-- <Handler
+          class="org.picketlink.identity.federation.web.handlers.saml2.SAML2SignatureGenerationHandler" /> -->
+    <!-- <Handler
+          class="org.picketlink.identity.federation.web.handlers.saml2.SAML2SignatureValidationHandler"/> -->
 
   </Handlers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
   </scm>
 
   <modules>
+    <module>service</module>
     <module>packaging</module>
   </modules>
 
@@ -64,6 +65,11 @@
         <version>${org.exoplatform.commons-exo.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.exoplatform.addons.sso</groupId>
+        <artifactId>saml2-addon-service</artifactId>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Copyright (C) 2003-2023 eXo Platform SAS.
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Affero General Public License
+  as published by the Free Software Foundation; either version 3
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, see<http://www.gnu.org/licenses />.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.addons.sso</groupId>
+    <artifactId>saml2-addon-parent</artifactId>
+    <version>7.1.x-SNAPSHOT</version>
+  </parent>
+  <artifactId>saml2-addon-service</artifactId>
+  <name>eXo Add-on:: SAML2 add-on Service</name>
+  <description>The SAML2 add-on Service</description>
+  <dependencies>
+    <dependency>
+      <groupId>io.meeds.gatein.sso</groupId>
+      <artifactId>sso-saml-plugin</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <finalName>${project.artifactId}</finalName>
+  </build>
+</project>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.addons.sso</groupId>
     <artifactId>saml2-addon-parent</artifactId>
-    <version>7.1.x-SNAPSHOT</version>
+    <version>7.0.x-SNAPSHOT</version>
   </parent>
   <artifactId>saml2-addon-service</artifactId>
   <name>eXo Add-on:: SAML2 add-on Service</name>

--- a/service/src/main/java/org/exoplatform/addons/saml/extensions/SAML2ExtendedAuthenticationHandler.java
+++ b/service/src/main/java/org/exoplatform/addons/saml/extensions/SAML2ExtendedAuthenticationHandler.java
@@ -1,0 +1,322 @@
+package org.exoplatform.addons.saml.extensions;
+
+import jakarta.servlet.http.HttpSession;
+import org.picketlink.common.constants.GeneralConstants;
+import org.picketlink.common.constants.JBossSAMLConstants;
+import org.picketlink.common.constants.JBossSAMLURIConstants;
+import org.picketlink.common.exceptions.ConfigurationException;
+import org.picketlink.common.exceptions.ProcessingException;
+import org.picketlink.common.exceptions.fed.AssertionExpiredException;
+import org.picketlink.common.util.DocumentUtil;
+import org.picketlink.common.util.StaxParserUtil;
+import org.picketlink.common.util.StringUtil;
+import org.picketlink.config.federation.SPType;
+import org.picketlink.identity.federation.api.saml.v2.response.SAML2Response;
+import org.picketlink.identity.federation.core.SerializablePrincipal;
+import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
+import org.picketlink.identity.federation.core.saml.v2.interfaces.SAML2Handler;
+import org.picketlink.identity.federation.core.saml.v2.interfaces.SAML2HandlerRequest;
+import org.picketlink.identity.federation.core.saml.v2.interfaces.SAML2HandlerResponse;
+import org.picketlink.identity.federation.core.saml.v2.util.AssertionUtil;
+import org.picketlink.identity.federation.core.util.JAXPValidationUtil;
+import org.picketlink.identity.federation.core.util.XMLEncryptionUtil;
+import org.picketlink.identity.federation.saml.v2.assertion.AssertionType;
+import org.picketlink.identity.federation.saml.v2.assertion.AttributeStatementType;
+import org.picketlink.identity.federation.saml.v2.assertion.AttributeType;
+import org.picketlink.identity.federation.saml.v2.assertion.EncryptedAssertionType;
+import org.picketlink.identity.federation.saml.v2.assertion.NameIDType;
+import org.picketlink.identity.federation.saml.v2.assertion.StatementAbstractType;
+import org.picketlink.identity.federation.saml.v2.assertion.SubjectType;
+import org.picketlink.identity.federation.saml.v2.protocol.ResponseType;
+import org.picketlink.identity.federation.saml.v2.protocol.StatusType;
+import org.picketlink.identity.federation.web.core.HTTPContext;
+import org.picketlink.identity.federation.web.handlers.saml2.SAML2AuthenticationHandler;
+import org.picketlink.identity.federation.web.interfaces.IRoleValidator;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import javax.xml.namespace.QName;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.picketlink.common.util.StringUtil.isNotNull;
+
+public class SAML2ExtendedAuthenticationHandler extends SAML2AuthenticationHandler {
+  private final SPExtendedAuthenticationHandler sp = new SPExtendedAuthenticationHandler();
+
+  @Override
+  public void handleStatusResponseType(SAML2HandlerRequest request, SAML2HandlerResponse response) throws ProcessingException {
+    if (request.getSAML2Object() instanceof ResponseType == false)
+      return;
+
+    if (getType() == HANDLER_TYPE.IDP) {
+      super.handleStatusResponseType(request, response);
+    } else {
+      sp.handleStatusResponseType(request, response);
+    }
+  }
+
+  private class SPExtendedAuthenticationHandler {
+
+    public void handleStatusResponseType(SAML2HandlerRequest request, SAML2HandlerResponse response)
+        throws ProcessingException {
+      HTTPContext httpContext = (HTTPContext) request.getContext();
+      ResponseType responseType = (ResponseType) request.getSAML2Object();
+
+      checkDestination(responseType.getDestination(), getSPConfiguration().getServiceURL());
+
+      List<ResponseType.RTChoiceType> assertions = responseType.getAssertions();
+      if (assertions.size() == 0)
+        throw logger.samlHandlerNoAssertionFromIDP();
+
+      PrivateKey privateKey = (PrivateKey) request.getOptions().get(GeneralConstants.DECRYPTING_KEY);
+
+      Object assertion = assertions.get(0).getEncryptedAssertion();
+      if (assertion instanceof EncryptedAssertionType) {
+        responseType = this.decryptAssertion(responseType, privateKey);
+        assertion = responseType.getAssertions().get(0).getAssertion();
+      }
+      if (assertion == null) {
+        assertion = assertions.get(0).getAssertion();
+      }
+
+      request.addOption(GeneralConstants.ASSERTION, assertion);
+
+      Principal userPrincipal = handleSAMLResponse(responseType, response);
+      if (userPrincipal == null) {
+        response.setError(403, "User Principal not determined: Forbidden");
+      } else {
+        HttpSession session = httpContext.getRequest().getSession(false);
+
+        // add the principal to the session
+        session.setAttribute(GeneralConstants.PRINCIPAL_ID, userPrincipal);
+
+        Document responseDocument = request.getRequestDocument();
+        Element assertionElement =
+            DocumentUtil.getChildElement(responseDocument.getDocumentElement(),
+                                         new QName(JBossSAMLConstants.ASSERTION.get()));
+
+        if (assertionElement != null) {
+          try {
+            Document assertionDocument = DocumentUtil.createDocument();
+            Node clonedAssertion = assertionElement.cloneNode(true);
+
+            assertionDocument.adoptNode(clonedAssertion);
+            assertionDocument.appendChild(clonedAssertion);
+
+            String assertionAttributeName = (String) handlerConfig
+                .getParameter(GeneralConstants.ASSERTION_SESSION_ATTRIBUTE_NAME);
+
+            if (assertionAttributeName != null) {
+              session.setAttribute(assertionAttributeName, assertionDocument);
+            }
+
+            session.setAttribute(GeneralConstants.ASSERTION_SESSION_ATTRIBUTE_NAME, assertionDocument);
+          } catch (ConfigurationException e) {
+            throw new ProcessingException("Could not store assertion document into session.", e);
+          }
+        }
+      }
+    }
+
+
+    private ResponseType decryptAssertion(ResponseType responseType, PrivateKey privateKey) throws ProcessingException {
+      if (privateKey == null)
+        throw logger.nullArgumentError("privateKey");
+      SAML2Response saml2Response = new SAML2Response();
+      try {
+        Document doc = saml2Response.convert(responseType);
+
+        Element enc = DocumentUtil.getElement(doc, new QName(JBossSAMLConstants.ENCRYPTED_ASSERTION.get()));
+        if (enc == null)
+          throw logger.samlHandlerNullEncryptedAssertion();
+        String oldID = enc.getAttribute(JBossSAMLConstants.ID.get());
+        Document newDoc = DocumentUtil.createDocument();
+        Node importedNode = newDoc.importNode(enc, true);
+        newDoc.appendChild(importedNode);
+
+        Element decryptedDocumentElement = XMLEncryptionUtil.decryptElementInDocument(newDoc, privateKey);
+        SAMLParser parser = new SAMLParser();
+
+        JAXPValidationUtil.checkSchemaValidation(decryptedDocumentElement);
+        AssertionType assertion = (AssertionType) parser.parse(StaxParserUtil.getXMLEventReader(DocumentUtil
+                                                                                                    .getNodeAsStream(decryptedDocumentElement)));
+
+        responseType.replaceAssertion(oldID, new ResponseType.RTChoiceType(assertion));
+        return responseType;
+      } catch (Exception e) {
+        throw logger.processingError(e);
+      }
+    }
+
+    private Principal handleSAMLResponse(ResponseType responseType, SAML2HandlerResponse response)
+        throws ProcessingException {
+      if (responseType == null)
+        throw logger.nullArgumentError("response type");
+
+      StatusType statusType = responseType.getStatus();
+      if (statusType == null)
+        throw logger.nullArgumentError("Status Type from the IDP");
+
+      String statusValue = statusType.getStatusCode().getValue().toASCIIString();
+      if (JBossSAMLURIConstants.STATUS_SUCCESS.get().equals(statusValue) == false)
+        throw logger.samlHandlerIDPAuthenticationFailedError();
+
+      List<ResponseType.RTChoiceType> assertions = responseType.getAssertions();
+      if (assertions.size() == 0)
+        throw logger.samlHandlerNoAssertionFromIDP();
+
+      AssertionType assertion = assertions.get(0).getAssertion();
+      // Check for validity of assertion
+      boolean expiredAssertion;
+      try {
+        String skew = (String) handlerConfig.getParameter(SAML2Handler.CLOCK_SKEW_MILIS);
+        if (isNotNull(skew)) {
+          long skewMilis = Long.parseLong(skew);
+          expiredAssertion = AssertionUtil.hasExpired(assertion, skewMilis);
+        } else
+          expiredAssertion = AssertionUtil.hasExpired(assertion);
+      } catch (ConfigurationException e) {
+        throw new ProcessingException(e);
+      }
+      if (expiredAssertion) {
+        AssertionExpiredException aee = new AssertionExpiredException();
+        aee.setId(assertion.getID());
+        throw logger.assertionExpiredError(aee);
+      }
+
+      if (!AssertionUtil.isAudience(assertion, getSPConfiguration())) {
+        throw logger.samlAssertionWrongAudience(getSPConfiguration().getServiceURL());
+      }
+
+      SubjectType subject = assertion.getSubject();
+      /*
+       * JAXBElement<NameIDType> jnameID = (JAXBElement<NameIDType>) subject.getContent().get(0); NameIDType nameID =
+       * jnameID.getValue();
+       */
+      if (subject == null)
+        throw logger.nullValueError("Subject in the assertion");
+
+      SubjectType.STSubType subType = subject.getSubType();
+      if (subType == null)
+        throw logger.nullValueError("Unable to find subtype via subject");
+      NameIDType nameID = (NameIDType) subType.getBaseID();
+
+      if (nameID == null)
+        throw logger.nullValueError("Unable to find username via subject");
+
+      String userName = nameID.getValue();
+      if (!Boolean.parseBoolean((String)handlerConfig.getParameter("USE_NAMEID"))) {
+        Set<StatementAbstractType> statements = assertion.getStatements();
+        for (StatementAbstractType statement : statements) {
+          if (statement instanceof AttributeStatementType attributeStatement) {
+            List<AttributeStatementType.ASTChoiceType> attList = attributeStatement.getAttributes();
+            for (AttributeStatementType.ASTChoiceType obj : attList) {
+              AttributeType attr = obj.getAttribute();
+              if ((attr.getFriendlyName() != null && attr.getFriendlyName().equals(handlerConfig.getParameter("SUBJECT_ATTRIBUTE"))) ||
+                  (attr.getName() != null && attr.getName().equals(handlerConfig.getParameter("SUBJECT_ATTRIBUTE")))) {
+                if (attr.getAttributeValue() != null) {
+                  userName = (String) attr.getAttributeValue().get(0);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      List<String> roles = new ArrayList<>();
+
+      // Let us get the roles
+      Set<StatementAbstractType> statements = assertion.getStatements();
+      for (StatementAbstractType statement : statements) {
+        if (statement instanceof AttributeStatementType attributeStatement) {
+          roles.addAll(getRoles(attributeStatement));
+        }
+      }
+
+      response.setRoles(roles);
+
+      Principal principal = new SerializablePrincipal(userName);
+
+      if (handlerChainConfig.getParameter(GeneralConstants.ROLE_VALIDATOR_IGNORE) == null) {
+        // Validate the roles
+        IRoleValidator roleValidator = (IRoleValidator) handlerChainConfig
+            .getParameter(GeneralConstants.ROLE_VALIDATOR);
+        if (roleValidator == null)
+          throw logger.nullValueError("Role Validator");
+
+        boolean validRole = roleValidator.userInRole(principal, roles);
+
+        if (!validRole) {
+          logger.trace("Invalid role: " + roles);
+          principal = null;
+        }
+      }
+      return principal;
+    }
+
+    /**
+     * Get the roles from the attribute statement
+     *
+     * @param attributeStatement
+     *
+     * @return
+     */
+    private List<String> getRoles(AttributeStatementType attributeStatement) {
+      List<String> roles = new ArrayList<String>();
+
+      // PLFED-141: Disable role picking from IDP response
+      if (handlerConfig.containsKey(DISABLE_ROLE_PICKING)) {
+        String val = (String) handlerConfig.getParameter(DISABLE_ROLE_PICKING);
+        if (isNotNull(val) && "true".equalsIgnoreCase(val))
+          return roles;
+      }
+
+      // PLFED-140: which of the attribute statements represent roles?
+      List<String> roleKeys = new ArrayList<String>();
+
+      if (handlerConfig.containsKey(ROLE_KEY)) {
+        String roleKey = (String) handlerConfig.getParameter(ROLE_KEY);
+        if (isNotNull(roleKey)) {
+          roleKeys.addAll(StringUtil.tokenize(roleKey));
+        }
+      }
+
+      List<AttributeStatementType.ASTChoiceType> attList = attributeStatement.getAttributes();
+      for (AttributeStatementType.ASTChoiceType obj : attList) {
+        AttributeType attr = obj.getAttribute();
+        if (roleKeys.size() > 0) {
+          if (!roleKeys.contains(attr.getName()))
+            continue;
+        }
+        List<Object> attributeValues = attr.getAttributeValue();
+        if (attributeValues != null) {
+          for (Object attrValue : attributeValues) {
+            if (attrValue instanceof String) {
+              roles.add((String) attrValue);
+            } else if (attrValue instanceof Node) {
+              Node roleNode = (Node) attrValue;
+              roles.add(roleNode.getFirstChild().getNodeValue());
+            } else
+              throw logger.unsupportedRoleType(attrValue);
+          }
+        }
+      }
+      return roles;
+    }
+
+    private SPType getSPConfiguration() {
+      SPType spConfiguration = (SPType) handlerChainConfig.getParameter(GeneralConstants.CONFIGURATION);
+
+      if (spConfiguration == null) {
+        throw logger.samlHandlerServiceProviderConfigNotFound();
+      }
+
+      return spConfiguration;
+    }
+  }
+}


### PR DESCRIPTION
This addons allows to configure how exo read the assertions, in order to be able to work with persistent and transient name-id, and read username in another attribute